### PR TITLE
Fix update annotation endpoint

### DIFF
--- a/annotation_server/annotations/urls.py
+++ b/annotation_server/annotations/urls.py
@@ -1,9 +1,13 @@
 from django.urls import path
-from annotations.views import create_annotation, update_annotation, delete_annotation
+from annotations.views import (
+    create_annotation,
+    update_annotation,
+    delete_annotation,
+)
 
 urlpatterns = [
     # Other URL patterns
     path('annotations/', create_annotation, name='create_annotation'),
     path('annotations/<int:annotation_id>/', update_annotation, name='update_annotation'),
-    path('annotations/<int:annotation_id>/', delete_annotation, name='delete_annotation'),
+    path('annotations/<int:annotation_id>/delete/', delete_annotation, name='delete_annotation'),
 ]

--- a/annotation_server/annotations/views.py
+++ b/annotation_server/annotations/views.py
@@ -1,5 +1,6 @@
 from django.http import Http404, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
+import json
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -26,7 +27,11 @@ def update_annotation(request, annotation_id):
         return JsonResponse({"error": "Annotation does not exist"}, status=404)
 
     if request.method == 'PUT':
-        serializer = AnnotationSerializer(annotation, data=request.PUT)
+        try:
+            data = json.loads(request.body.decode("utf-8"))
+        except json.JSONDecodeError:
+            data = {}
+        serializer = AnnotationSerializer(annotation, data=data)
         if serializer.is_valid():
             serializer.save()
             return JsonResponse(serializer.data)


### PR DESCRIPTION
## Summary
- update URL for delete annotation endpoint
- parse JSON data correctly when updating annotations

## Testing
- `python -m py_compile annotation_server/annotations/views.py annotation_server/annotations/urls.py`

------
https://chatgpt.com/codex/tasks/task_e_684d6360b2948324b3fe0414513a3140