### PR TITLE
Add dark theme support

### DIFF
--- a/application_server/movie_app/static/css/theme.css
+++ b/application_server/movie_app/static/css/theme.css
@@ -1,0 +1,38 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --navbar-bg: rgb(210, 123, 0);
+  --card-bg: #ffffff;
+  --card-border: #dee2e6;
+}
+
+body.dark-mode {
+  --bg-color: #121212;
+  --text-color: #ffffff;
+  --navbar-bg: #333333;
+  --card-bg: #1e1e1e;
+  --card-border: #555555;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.navbar {
+  background-color: var(--navbar-bg) !important;
+}
+
+.themed-container,
+.card {
+  background-color: var(--card-bg) !important;
+  color: var(--text-color) !important;
+  border-color: var(--card-border) !important;
+}
+
+.list-group-item,
+.modal-content {
+  background-color: var(--card-bg) !important;
+  color: var(--text-color) !important;
+  border-color: var(--card-border) !important;
+}

--- a/application_server/movie_app/templates/base.html
+++ b/application_server/movie_app/templates/base.html
@@ -12,6 +12,7 @@
 
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+    <link rel='stylesheet' href='{% static 'css/theme.css' %}'>
 
     <title>{% block title %}{% endblock %}</title>
 
@@ -52,6 +53,9 @@
                     <input class="form-control mr-sm-2" type="search" name="query" placeholder="Search" aria-label="Search" required>
                     <input class="btn btn-outline-success mx-2 my-2 my-sm-0" type="submit" value="Search">
                 </form>
+                </li>
+            <li class="nav-item">
+                <button id="themeToggle" class="btn btn-secondary ml-2">Dark Mode</button>
             </li>
         </ul>
 
@@ -171,6 +175,20 @@
 
 <!-- Optional: Include jQuery and Bootstrap Bundle (includes Popper) -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+<script>
+    const toggle = document.getElementById("themeToggle");
+    if (toggle) {
+        toggle.addEventListener("click", function() {
+            document.body.classList.toggle("dark-mode");
+            localStorage.setItem("theme", document.body.classList.contains("dark-mode") ? "dark" : "light");
+        });
+    }
+    (function(){
+        if(localStorage.getItem("theme") === "dark"){
+            document.body.classList.add("dark-mode");
+        }
+    })();
+</script>
 
 </body>
 </html>

--- a/application_server/movie_app/templates/contact.html
+++ b/application_server/movie_app/templates/contact.html
@@ -5,7 +5,7 @@
 {% block body %}
 
 <div class="jumbotron jumbotron-fluid">
-    <div class="container-fluid" style="margin-top:30px; background: white; box-shadow: 1px 1px 10px 1px black; padding: 10px; width: 600px;">
+    <div class="container-fluid themed-container" style="margin-top:30px; box-shadow: 1px 1px 10px 1px black; padding: 10px; width: 600px;">
         <form method="post" action="{% url 'contact' %}">
             {% csrf_token %}
         <h1>Contact Form</h1>

--- a/application_server/movie_app/templates/create_post.html
+++ b/application_server/movie_app/templates/create_post.html
@@ -4,7 +4,7 @@
 {% block body %}
 
 <div class="jumbotron jumbotron-fluid">
-    <div class="container-fluid" style="margin-top: -40px; background: white; box-shadow: 1px 1px 10px 1px black; padding: 10px; width: 800px;">
+    <div class="container-fluid themed-container" style="margin-top: -40px; box-shadow: 1px 1px 10px 1px black; padding: 10px; width: 800px;">
         <form id="postForm" action="{% url 'post_created' %}" method="post">
             {% csrf_token %}
             <h1>Write a Post</h1>

--- a/application_server/movie_app/templates/home.html
+++ b/application_server/movie_app/templates/home.html
@@ -14,7 +14,7 @@
   </div>
 
   <div class="container">
-    <div class="container" style="border-radius: 10px; box-shadow: 1px 1px 10px 1px black; background:rgb(243, 6, 6); padding-bottom:10px; margin-top:-130px;margin-left:500px; border: 1px solid rgb(9, 9, 9); width: 600px;">
+    <div class="container themed-container" style="border-radius: 10px; box-shadow: 1px 1px 10px 1px black; padding-bottom:10px; margin-top:-130px;margin-left:500px; border: 1px solid rgb(9, 9, 9); width: 600px;">
       <form action="{% url 'login' %}" method="post">
         {% csrf_token %}
   <div class="form-group">

--- a/application_server/movie_app/tests.py
+++ b/application_server/movie_app/tests.py
@@ -1,3 +1,43 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
+from unittest.mock import patch, MagicMock
 
-# Create your tests here.
+from .views import get_wikidata_explanations
+
+
+class GetWikidataExplanationsTests(SimpleTestCase):
+    """Tests for the ``get_wikidata_explanations`` helper."""
+
+    @patch("movie_app.views.requests.get")
+    def test_returns_explanation_for_valid_id(self, mock_get):
+        """Should return a list with label and description when the API succeeds."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "entities": {
+                "Q42": {
+                    "labels": {"en": {"value": "Douglas Adams"}},
+                    "descriptions": {"en": {"value": "English writer"}},
+                }
+            }
+        }
+        mock_get.return_value = mock_response
+
+        result = get_wikidata_explanations("Q42")
+        expected = [
+            {
+                "label": "Douglas Adams",
+                "description": "English writer",
+                "concepturi": "https://www.wikidata.org/wiki/Q42",
+            }
+        ]
+        self.assertEqual(result, expected)
+
+    @patch("movie_app.views.requests.get")
+    def test_returns_empty_list_on_failure(self, mock_get):
+        """Should return an empty list when the API response is not successful."""
+        mock_get.return_value.status_code = 500
+        mock_get.return_value.json.return_value = {}
+
+        result = get_wikidata_explanations("Q999999")
+        self.assertEqual(result, [])
+


### PR DESCRIPTION
## Summary
- add a reusable dark theme stylesheet
- include theme on base template and provide a Dark Mode toggle
- ensure login and contact forms use themed containers

## Testing
- `pip install -r requirements.txt`
- `python application_server/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684ff877d60c832483119e34bcf0e473